### PR TITLE
feat : 카테고리별 해시태그 컴포넌트 생성

### DIFF
--- a/src/component/Hashtag.tsx
+++ b/src/component/Hashtag.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Body2_3 } from 'styles/font';
+import { theme } from 'styles/theme';
+
+interface IHashtag {
+  category: string;
+}
+
+interface hashtags {
+  [key: string]: any;
+}
+
+const HashtagColors: hashtags = {
+  restaurant: theme.colors.purple,
+  coffee: theme.colors.green,
+  birthday: theme.colors.blue,
+};
+
+const HashtagTexts: hashtags = {
+  restaurant: '맛집',
+  coffee: '카페',
+  birthday: '생일 카페',
+};
+
+export const Hashtag = ({ category }: IHashtag) => {
+  return (
+    <HashtagContainer color={`${HashtagColors[category]}`}>
+      <Body2_3>#{`${HashtagTexts[category]}`}</Body2_3>
+    </HashtagContainer>
+  );
+};
+
+const HashtagContainer = styled.div`
+  margin-top: 60px;
+  padding: 5px 15px 5px 10px;
+
+  height: 30px;
+
+  border-radius: 100px;
+  background-color: ${({ color }) => (color ? color : '')};
+`;

--- a/src/component/LocationInfo.tsx
+++ b/src/component/LocationInfo.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Body1_1, Body2_3 } from 'styles/font';
 import { IPlace } from 'utils/interface';
+import { Hashtag } from './Hashtag';
 
 export const LocationInfo = ({ focused }: { focused: IPlace | null }) => {
   return (
@@ -10,6 +11,9 @@ export const LocationInfo = ({ focused }: { focused: IPlace | null }) => {
         <Body1_1>{focused?.name}</Body1_1>
         <Body2_3>{focused?.address}</Body2_3>
       </LocationInfoTop>
+      <div>
+        <Hashtag category={`${focused?.category}`} />
+      </div>
     </LocationInfoContainer>
   );
 };

--- a/src/component/LocationInfo.tsx
+++ b/src/component/LocationInfo.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Body1_1, Body2_3 } from 'styles/font';
 import { IPlace } from 'utils/interface';
 import { Hashtag } from './Hashtag';
+import { MemberHashtag } from './MemberHashtag';
 
 export const LocationInfo = ({ focused }: { focused: IPlace | null }) => {
   return (
@@ -11,9 +12,10 @@ export const LocationInfo = ({ focused }: { focused: IPlace | null }) => {
         <Body1_1>{focused?.name}</Body1_1>
         <Body2_3>{focused?.address}</Body2_3>
       </LocationInfoTop>
-      <div>
+      <HashtagWrap>
+        <MemberHashtag group={'BTS'} name={'정국'} />
         <Hashtag category={`${focused?.category}`} />
-      </div>
+      </HashtagWrap>
     </LocationInfoContainer>
   );
 };
@@ -42,4 +44,8 @@ const LocationInfoTop = styled.div`
 
   display: flex;
   flex-direction: column;
+`;
+
+const HashtagWrap = styled.div`
+  display: flex;
 `;

--- a/src/component/MemberHashtag.tsx
+++ b/src/component/MemberHashtag.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Body2_3 } from 'styles/font';
+import { theme } from 'styles/theme';
+import { IPeoples } from 'utils/interface';
+
+export const MemberHashtag = ({ group, name }: IPeoples) => {
+  return (
+    <HashtagContainer>
+      <Body2_3 color={`${theme.colors.white}`}>
+        #{group}_{name}
+      </Body2_3>
+    </HashtagContainer>
+  );
+};
+
+const HashtagContainer = styled.div`
+  margin-top: 60px;
+  margin-right: 10px;
+  padding: 5px 15px 5px 10px;
+
+  height: 30px;
+
+  border-radius: 100px;
+  background-color: ${({ theme }) => theme.colors.black};
+`;

--- a/src/utils/interface.ts
+++ b/src/utils/interface.ts
@@ -10,3 +10,8 @@ export interface IPlace {
   longitude: number;
   category: string;
 }
+
+export interface IPeoples {
+  group: string;
+  name: string;
+}


### PR DESCRIPTION
<p display="flex">
<img width="180" alt="Screenshot 2023-09-24 at 4 19 14 AM" src="https://github.com/unithon-10th-10team/DeokjiDeokji_FE/assets/80371353/0b9cd1bb-a654-4d07-b4fc-be081a263778">
<img width="180" alt="Screenshot 2023-09-24 at 4 19 32 AM" src="https://github.com/unithon-10th-10team/DeokjiDeokji_FE/assets/80371353/efca9572-32ac-4790-b557-8c973f71c521">
<img width="180" alt="Screenshot 2023-09-24 at 4 19 47 AM" src="https://github.com/unithon-10th-10team/DeokjiDeokji_FE/assets/80371353/a477bdeb-f0e6-4542-bc31-4ae95c4128fb">
<img width="180" alt="Screenshot 2023-09-24 at 4 42 34 AM" src="https://github.com/unithon-10th-10team/DeokjiDeokji_FE/assets/80371353/ac0a2183-6e21-43c3-b96a-39419d92219e">
</p>
- 카테고리별 해시태그 및 그룹과 멤버 해시태그 컴포넌트 구현 완료했습니다!
